### PR TITLE
feat: add upgrade role functionality for customers to become hotel owner to manage hotel

### DIFF
--- a/src/modules/users/controllers/users.controller.ts
+++ b/src/modules/users/controllers/users.controller.ts
@@ -18,7 +18,12 @@ import { AllowRoles } from '@/modules/auth/decorators/allow-roles.decorator';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import { Role } from '@/modules/auth/enums/role.enum';
 
-import { DeletedUserProfileDto, UpdateUserDto, UserProfileDto } from '../dtos/user.dtos';
+import {
+  DeletedUserProfileDto,
+  UpdateUserDto,
+  UpgradeRoleDto,
+  UserProfileDto,
+} from '../dtos/user.dtos';
 import { User } from '../schemas/user.schema';
 import { UsersService } from '../services/users.service';
 
@@ -135,5 +140,21 @@ export class UsersController {
     return this.usersService.restore({
       _id: id,
     });
+  }
+
+  @ApiOperation({
+    summary: "Upgrade current user's role from CUSTOMER to HOTEL_OWNER",
+    description:
+      'Allows a customer to upgrade their role to hotel owner to add hotels to the system. All existing data (booking history, favorite hotels, etc.) will be preserved.',
+  })
+  @ApiSuccessResponse({
+    schema: UserProfileDto,
+    description: 'User role upgraded successfully',
+  })
+  @AllowRoles([Role.CUSTOMER])
+  @Patch('/upgrade-role')
+  async upgradeUserRole(@CurrentUser() currentUser: User, @Body() upgradeRoleDto: UpgradeRoleDto) {
+    const user = await this.usersService.upgradeUserRole(currentUser, upgradeRoleDto);
+    return UserProfileDto.mapToDto(user);
   }
 }

--- a/src/modules/users/dtos/user.dtos.ts
+++ b/src/modules/users/dtos/user.dtos.ts
@@ -72,3 +72,26 @@ export class UpdateUserDto {
   @IsEnum(Gender)
   gender?: Gender;
 }
+
+export class UpgradeRoleDto {
+  @ApiProperty({
+    description: 'The target role to upgrade to',
+    enum: [Role.HOTEL_OWNER],
+    enumName: 'UpgradeRole',
+    example: Role.HOTEL_OWNER,
+    required: true,
+  })
+  @IsEnum([Role.HOTEL_OWNER], {
+    message: 'Only upgrade to HOTEL_OWNER role is supported',
+  })
+  targetRole!: Role.HOTEL_OWNER;
+
+  @ApiProperty({
+    description: 'Optional justification for the role upgrade',
+    example: 'I want to add my hotel to the system',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { BaseService } from '@/base/services';
+import { Role } from '@/modules/auth/enums/role.enum';
 
-import { UpdateUserDto } from '../dtos/user.dtos';
+import { UpdateUserDto, UpgradeRoleDto } from '../dtos/user.dtos';
 import { User } from '../schemas/user.schema';
 
 @Injectable()
@@ -20,5 +21,31 @@ export class UsersService extends BaseService<User> {
         _id: user._id,
       })
     )[0];
+  }
+
+  async upgradeUserRole(user: User, payload: UpgradeRoleDto) {
+    // Check if user is currently a CUSTOMER
+    if (user.role !== Role.CUSTOMER) {
+      throw new BadRequestException(
+        `Cannot upgrade role from ${user.role}. Only CUSTOMER role can be upgraded to HOTEL_OWNER.`,
+      );
+    }
+
+    // Check if target role is HOTEL_OWNER
+    if (payload.targetRole !== Role.HOTEL_OWNER) {
+      throw new BadRequestException('Only upgrade to HOTEL_OWNER role is supported.');
+    }
+
+    // Update the user's role while preserving all existing data
+    const updatedUser = await this.update(
+      {
+        role: payload.targetRole,
+      },
+      {
+        _id: user._id,
+      },
+    );
+
+    return updatedUser[0];
   }
 }


### PR DESCRIPTION
Add new API for users [PATCH]:
[/api/v1/users/upgrade-role]

Upgrade current user's role from CUSTOMER to HOTEL_OWNER (for CUSTOMER only)
Allows a customer to upgrade their role to hotel owner to add hotels to the system. All existing data (booking history, favorite hotels, etc.) will be preserved.

